### PR TITLE
fix logic in configureHMC for handing PP nodes

### DIFF
--- a/nimbleHMC/DESCRIPTION
+++ b/nimbleHMC/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: nimbleHMC
 Title: Hamiltonian Monte Carlo and Other Gradient-Based MCMC Sampling Algorithms for 'nimble'
-Version: 0.1.0
-Date: 2023-05-30
+Version: 0.1.1
+Date: 2023-07-07
 Authors@R: c(person("Daniel", "Turek", role = c("aut", "cre"), email = "danielturek@gmail.com"),
 	     person("Perry", "de Valpine", role = "aut"),
 	     person("Christopher", "Paciorek", role = "aut"))

--- a/nimbleHMC/R/configuration.R
+++ b/nimbleHMC/R/configuration.R
@@ -5,7 +5,7 @@
 #' Add a Hamiltonian Monte Carlo (HMC) sampler to an existing nimble MCMC configuration object
 #'
 #' @param conf A nimble MCMC configuration object, as returned by `configureMCMC`.
-#' @param nodes A character vector of continuous-valued stochastic node names to sample by HMC. If an empty character vector is provided (the default), then an HMC sampler will be applied to all continuous-valued non-data stochastic nodes.  If this argument contains any discrete-valued nodes, an error is produced and no HMC sampler is added.
+#' @param nodes A character vector of continuous-valued stochastic node names to sample by HMC.  If this argument contains any discrete-valued nodes, an error is produced and no HMC sampler is added.
 #' @param control Optional named list of control parameters to be passed as the `control` argument to `sampler_HMC`.  See `help(sampler_HMC)` for details.
 #' @param replace Logical argument.  If `TRUE`, any existing samplers operating on the specified nodes will be removed, prior to adding the HMC sampler.  Default value is `FALSE`.
 #' @param print Logical argument whether to print the newly added HMC sampler.  Default value is `TRUE`.
@@ -58,11 +58,7 @@
 #' # Cmcmc <- compileNimble(Rmcmc, project = Rmodel)
 #' # samples <- runMCMC(Cmcmc)
 addHMC <- function(conf, nodes = character(), control = list(), replace = FALSE, print = TRUE) {
-    if(identical(nodes, character())) {
-        nodes <- conf$model$getNodeNames(stochOnly = TRUE, includeData = FALSE)
-        nodes <- nodes[!conf$model$isDiscrete(nodes)]
-        if(length(nodes) == 0) stop('model contains no continuous-valued stochastic non-data nodes', call. = FALSE)
-    }
+    if(identical(nodes, character()))  return()
     nodesExpanded <- conf$model$expandNodeNames(nodes)
     if(length(nodesExpanded)) {
         discreteNodes <- nodesExpanded[conf$model$isDiscrete(nodesExpanded)]
@@ -323,9 +319,14 @@ nimbleHMC <- function(code,
 hmc_determineNodeLists <- function(model) {
     ppNodes <- model$getNodeNames(predictiveOnly = TRUE)   ## stochastic only, already
     stochNodes <- model$getNodeNames(stochOnly = TRUE, includeData = FALSE, includePredictive = FALSE)
-    isDiscreteBool <- model$isDiscrete(stochNodes)
-    stochContNodes <- stochNodes[!isDiscreteBool]
-    stochDiscNodes <- stochNodes[ isDiscreteBool]
+    if(length(stochNodes) > 0) {
+        isDiscreteBool <- model$isDiscrete(stochNodes)
+        stochContNodes <- stochNodes[!isDiscreteBool]
+        stochDiscNodes <- stochNodes[ isDiscreteBool]
+    } else {
+        stochContNodes <- character()
+        stochDiscNodes <- character()
+    }
     return(list(postPred  = ppNodes,
                 stochCont = stochContNodes,
                 stochDisc = stochDiscNodes))

--- a/nimbleHMC/R/configuration.R
+++ b/nimbleHMC/R/configuration.R
@@ -322,7 +322,7 @@ nimbleHMC <- function(code,
 ## create the lists of model nodes for use in HMC configuration functions
 hmc_determineNodeLists <- function(model) {
     ppNodes <- model$getNodeNames(predictiveOnly = TRUE)   ## stochastic only, already
-    stochNodes <- model$getNodeNames(stochOnly = TRUE, includeData = FALSE)
+    stochNodes <- model$getNodeNames(stochOnly = TRUE, includeData = FALSE, includePredictive = FALSE)
     isDiscreteBool <- model$isDiscrete(stochNodes)
     stochContNodes <- stochNodes[!isDiscreteBool]
     stochDiscNodes <- stochNodes[ isDiscreteBool]

--- a/nimbleHMC/inst/NEWS.md
+++ b/nimbleHMC/inst/NEWS.md
@@ -1,3 +1,7 @@
+#                            CHANGES IN VERSION 0.1.1 (July 2023)
+
+- Fix bug in `configureHMC` for sampler assignment to posterior predictive nodes.
+
 #                            VERSION 0.1.0 (May 2023)
 
 Initial release of `nimbleHMC` package.  Initial version provides:

--- a/nimbleHMC/tests/testthat/test-HMC.R
+++ b/nimbleHMC/tests/testthat/test-HMC.R
@@ -185,7 +185,9 @@ test_that('HMC on MVN node', {
     inits <- list(x = c(10, 20, 30))
     ##
     Rmodel <- nimbleModel(code, constants, data, inits, buildDerivs = TRUE)
-    Rmcmc <- buildHMC(Rmodel)
+    conf <- configureMCMC(Rmodel, nodes = NULL)
+    addHMC(conf, 'x')
+    Rmcmc <- buildMCMC(conf)
     ##
     compiledList <- compileNimble(list(model=Rmodel, mcmc=Rmcmc))
     Cmcmc <- compiledList$mcmc

--- a/nimbleHMC/tests/testthat/test-HMC.R
+++ b/nimbleHMC/tests/testthat/test-HMC.R
@@ -490,4 +490,23 @@ test_that('correctly assign samplers for discrete and continuous nodes', {
     expect_identical(as.character(class(Rmcmc$samplerFunctions$contentsList[[2]])), 'sampler_slice')
 })
 
+test_that('configureHMC correctly assign samplers for posterior-predictive nodes', {
+    code <- nimbleCode({
+        mu ~ dnorm(0,1)
+        sd ~ dunif(0, 10)
+        y ~ dnorm(mu, sd = sd)
+        pp ~ dnorm(mu, sd = sd)
+    })
+    constants <- list()
+    data <- list(y = 0)
+    inits <- list(mu = 0, sd = 1, pp = 0)
+    Rmodel <- nimbleModel(code, constants, data, inits, buildDerivs = TRUE)
+    conf <- configureHMC(Rmodel)
+    ##
+    expect_true(length(conf$samplerConfs) == 2)
+    expect_true(conf$samplerConfs[[1]]$name == 'HMC')
+    expect_identical(conf$samplerConfs[[1]]$target, c('mu', 'sd'))
+    expect_true(conf$samplerConfs[[2]]$name == 'posterior_predictive')
+    expect_identical(conf$samplerConfs[[2]]$target, 'pp')
+})
 


### PR DESCRIPTION
Fixes NCT issue 464, where it was noted that `configureHMC` (incorrectly) assigns HMC sampler to PP nodes.