### PR TITLE
updated hmc_checkTarget to use checkADsupportForDistribution

### DIFF
--- a/nimbleHMC/DESCRIPTION
+++ b/nimbleHMC/DESCRIPTION
@@ -15,3 +15,4 @@ Copyright: See COPYRIGHTS file.
 Encoding: UTF-8
 LazyData: false
 RoxygenNote: 7.3.1
+

--- a/nimbleHMC/R/HMC_samplers.R
+++ b/nimbleHMC/R/HMC_samplers.R
@@ -182,8 +182,7 @@ hmc_checkTarget <- function(model, targetNodes, hmcType) {
     dists <- targetDists_unique
     ADok <- rep(TRUE, length(dists))
     for(i in seq_along(dists)) {
-        dist_deparsed <- deparse(dists[i])
-        ADoak[i] <- model$getModelDef()$checkADsupportForDistribution(dist_deparsed)
+        ADoak[i] <- model$getModelDef()$checkADsupportForDistribution(dists[i])
     }
     if(!all(ADok))
         stop(paste0(hmcType, ' sampler cannot operate on user-defined distributions which do not support AD calculations.  Try using buildDerivs = TRUE in the definition the distributions: ', paste0(dists[!ADok], collapse = ', ')))

--- a/nimbleHMC/R/HMC_samplers.R
+++ b/nimbleHMC/R/HMC_samplers.R
@@ -182,22 +182,8 @@ hmc_checkTarget <- function(model, targetNodes, hmcType) {
     dists <- targetDists_unique
     ADok <- rep(TRUE, length(dists))
     for(i in seq_along(dists)) {
-        ##
-        ## if/when modelDef$checkADsupportForDistribution() is added to core nimble,
-        ## change the entire body of this for-loop to instead be:
-        ## ADoak[i] <- model$getModelDef()$checkADsupportForDistribution(dists[i])
-        ##
-        ## these distributions get re-named to a nimble-version, and won't be found:
-        if(dists[i] %in% c('dweib', 'dmnorm', 'dmvt', 'dwish', 'dinvwish'))   next
-        ##
-        ##
-        ## find the function or this distribution:
-        nfObj <- get(dists[i], envir = parent.frame(4))    ## this took a bit of an investigation to make work
-        ## is a user-defined distribution:
-        if(!is.null(environment(nfObj)$nfMethodRCobject)) {
-            ## check for AD support:
-            ADok[i] <- !isFALSE(environment(nfObj)$nfMethodRCobject[['buildDerivs']])
-        }
+        dist_deparsed <- deparse(dists[i])
+        ADoak[i] <- model$getModelDef()$checkADsupportForDistribution(dist_deparsed)
     }
     if(!all(ADok))
         stop(paste0(hmcType, ' sampler cannot operate on user-defined distributions which do not support AD calculations.  Try using buildDerivs = TRUE in the definition the distributions: ', paste0(dists[!ADok], collapse = ', ')))

--- a/nimbleHMC/R/HMC_samplers.R
+++ b/nimbleHMC/R/HMC_samplers.R
@@ -182,7 +182,7 @@ hmc_checkTarget <- function(model, targetNodes, hmcType) {
     dists <- targetDists_unique
     ADok <- rep(TRUE, length(dists))
     for(i in seq_along(dists)) {
-        ADoak[i] <- model$getModelDef()$checkADsupportForDistribution(dists[i])
+        ADok[i] <- model$getModelDef()$checkADsupportForDistribution(dists[i])
     }
     if(!all(ADok))
         stop(paste0(hmcType, ' sampler cannot operate on user-defined distributions which do not support AD calculations.  Try using buildDerivs = TRUE in the definition the distributions: ', paste0(dists[!ADok], collapse = ', ')))


### PR DESCRIPTION
I expect this will not pass testing (and would not get merged) until upcoming release of nimble package.

That said, @perrydv I would welcome a very quick code review.
