### PR TITLE
reorder final lines of NUTS run

### DIFF
--- a/nimbleHMC/R/HMC_samplers.R
+++ b/nimbleHMC/R/HMC_samplers.R
@@ -990,8 +990,6 @@ sampler_NUTS <- nimbleFunction(
         accept_prob <- sum_metropolis_prob / n_leapfrog
         copy_state(state_current, state_sample)        ## extraneous copy? could remove?
         ##
-        inverseTransformStoreCalculate(state_sample$q)
-        nimCopy(from = model, to = mvSaved, row = 1, nodes = calcNodes, logProb = TRUE)
         if((timesRan <= nwarmup) & adaptive) {
             if(adaptEpsilon)   adapt_stepsize(accept_prob)
             update <- FALSE
@@ -1004,6 +1002,8 @@ sampler_NUTS <- nimbleFunction(
                 mu <<- log(10*epsilon)
             }
         }
+        inverseTransformStoreCalculate(state_sample$q)
+        nimCopy(from = model, to = mvSaved, row = 1, nodes = calcNodes, logProb = TRUE)
     },
     methods = list(
         copy_state = function(to = stateNL(), from = stateNL()) {

--- a/nimbleHMC/R/HMC_samplers.R
+++ b/nimbleHMC/R/HMC_samplers.R
@@ -580,7 +580,7 @@ sampler_NUTS_classic <- nimbleFunction(
                             ##for(i in 1:d)   M[i] <<- 1 / warmupCovRegularized[i,i]
                             sqrtM <<- sqrt(M)
                             if(adaptEpsilon) {
-                                inverseTransformStoreCalculate(qNew) #defensively ensure model states are up to date
+                                inverseTransformStoreCalculate(qNew)   ## defensively ensure model states are up to date
                                 initEpsilon()
                                 epsilonAdaptCount <<- 0
                                 mu <<- log(10 * epsilon)
@@ -997,8 +997,8 @@ sampler_NUTS <- nimbleFunction(
             if(adaptM)   update <- adapt_M()
             if(update & adaptEpsilon) {
                 if(initializeEpsilon) {
-                  inverseTransformStoreCalculate(state_sample$q) # defensively ensure model states are up to date.
-                  initEpsilon()
+                    inverseTransformStoreCalculate(state_sample$q)   ## defensively ensure model states are up to date.
+                    initEpsilon()
                 }
                 Hbar <<- 0
                 logEpsilonBar <<- 0

--- a/nimbleHMC/R/HMC_samplers.R
+++ b/nimbleHMC/R/HMC_samplers.R
@@ -455,9 +455,9 @@ sampler_NUTS_classic <- nimbleFunction(
             j <- j + 1
             checkInterrupt()
         }
+        if((timesRan <= nwarmup) & adaptive)   adaptiveProcedure(btNL$a, btNL$na)
         inverseTransformStoreCalculate(qNew)
         nimCopy(from = model, to = mvSaved, row = 1, nodes = calcNodes, logProb = TRUE)
-        if((timesRan <= nwarmup) & adaptive)   adaptiveProcedure(btNL$a, btNL$na)
     },
     methods = list(
         drawMomentumValues = function() {
@@ -580,6 +580,7 @@ sampler_NUTS_classic <- nimbleFunction(
                             ##for(i in 1:d)   M[i] <<- 1 / warmupCovRegularized[i,i]
                             sqrtM <<- sqrt(M)
                             if(adaptEpsilon) {
+                                inverseTransformStoreCalculate(qNew) #defensively ensure model states are up to date
                                 initEpsilon()
                                 epsilonAdaptCount <<- 0
                                 mu <<- log(10 * epsilon)
@@ -995,7 +996,10 @@ sampler_NUTS <- nimbleFunction(
             update <- FALSE
             if(adaptM)   update <- adapt_M()
             if(update & adaptEpsilon) {
-                if(initializeEpsilon)   initEpsilon()
+                if(initializeEpsilon) {
+                  inverseTransformStoreCalculate(state_sample$q) # defensively ensure model states are up to date.
+                  initEpsilon()
+                }
                 Hbar <<- 0
                 logEpsilonBar <<- 0
                 stepsizeCounter <<- 0


### PR DESCRIPTION
In `sampler_NUTS`, this PR moves the final calls to `calculate` and `nimCopy` (that leave the model fully up-to-date upon exit) to be the last lines, appearing after the adaptation calls rather than before. This avoids the problem that the adaptation calls, when `initEpsilon` is called, use the model and hence can change its state.