### PR TITLE
added check in configureHMC for model buildDerivs = TRUE

### DIFF
--- a/nimbleHMC/R/HMC_configuration.R
+++ b/nimbleHMC/R/HMC_configuration.R
@@ -130,6 +130,8 @@ addHMC <- function(conf, target = character(), type = 'NUTS', control = list(), 
 #' # Cmcmc <- compileNimble(Rmcmc, project = Rmodel)
 #' # samples <- runMCMC(Cmcmc)
 configureHMC <- function(model, nodes = character(), type = 'NUTS', control = list(), print = TRUE, ...) {
+    if(!is.model(model)) stop('\'model\' argument must be a nimble model object',  call. = FALSE)
+    if(!isTRUE(model$modelDef[['buildDerivs']])) stop('must set buildDerivs = TRUE when building model',  call. = FALSE)
     nodesProvided <- !identical(nodes, character())
     if(nodesProvided) {
         nodes <- model$expandNodeNames(nodes)


### PR DESCRIPTION
Added a check in `configureHMC` to enforce that the model object was created using `buildDerivs = TRUE`.

Also added a check in `configureHMC` that the `model` argument to `configureHMC` is in fact a nimble model object.

This addresses NCT issue #559
